### PR TITLE
Add support for nodeTree request

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200
 SONATYPE_CLOSE_TIMEOUT_SECONDS=2000
 kotestVersion=2.0.2
-lionwebRepositoryCommitID=@lionweb/repository@0.2.0
+lionwebRepositoryCommitID=620f86ab5b8899b119b6360ab432113b3461253f

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.jvmargs=-Dfile.encoding=UTF-8
 SONATYPE_CONNECT_TIMEOUT_SECONDS=200
 SONATYPE_CLOSE_TIMEOUT_SECONDS=2000
 kotestVersion=2.0.2
-lionwebRepositoryCommitID=620f86ab5b8899b119b6360ab432113b3461253f
+lionwebRepositoryCommitID=1d1dbd625df1afd9da8a71e243f6726dde49970d

--- a/repo-client/src/functionalTest/kotlin/io/lionweb/lioncore/kotlin/repoclient/PropertiesFunctionalTest.kt
+++ b/repo-client/src/functionalTest/kotlin/io/lionweb/lioncore/kotlin/repoclient/PropertiesFunctionalTest.kt
@@ -304,7 +304,25 @@ class PropertiesFunctionalTest {
             }
         client.storeTree(pf)
 
-        val nodeTree1 = client.nodeTree("pf1")
-        val nodeTree2 = client.nodeTree(listOf("pp1","prop1"))
+        assertEquals(
+            listOf(
+                NodeInfo("pf1", "pp1", 0),
+                NodeInfo("prop1", "pf1", 1),
+                NodeInfo("prop2", "pf1", 1),
+                NodeInfo("prop3", "pf1", 1),
+            ),
+            client.nodeTree("pf1"),
+        )
+        assertEquals(
+            listOf(
+                NodeInfo("pp1", null, 0),
+                NodeInfo("prop1", "pf1", 0),
+                NodeInfo("pf1", "pp1", 1),
+                NodeInfo("prop1", "pf1", 2),
+                NodeInfo("prop2", "pf1", 2),
+                NodeInfo("prop3", "pf1", 2),
+            ),
+            client.nodeTree(listOf("pp1", "prop1")),
+        )
     }
 }

--- a/repo-client/src/functionalTest/resources/config-gen.py
+++ b/repo-client/src/functionalTest/resources/config-gen.py
@@ -1,0 +1,37 @@
+import os
+
+code = f"""{{
+  "server": {{
+    "serverPort": 3005,
+    "expectedToken": null
+  }},
+  "startup": {{
+    "createDatabase": true,
+    "createRepositories": [{{
+        "name": "default",
+        "history": false
+      }}
+    ]
+  }},
+  "logging": {{
+    "request": "silent",
+    "database": "silent",
+    "express": "silent"
+  }},
+  "postgres": {{
+    "database": {{
+      "host": "{os.environ['PGHOST']}",
+      "user": "{os.environ['PGUSER']}",
+      "db": "{os.environ['PGDB']}",
+      "password": "{os.environ['PGPASSWORD']}",
+      "port": "{os.environ['PGPORT']}"
+    }},
+    "certificates": {{
+      "rootcert": null,
+      "rootcertcontent": null
+    }}
+  }}
+}}
+"""
+with open("server-config.json", "w") as file:
+    file.write(code)

--- a/repo-client/src/functionalTest/resources/lionweb-repository-Dockerfile
+++ b/repo-client/src/functionalTest/resources/lionweb-repository-Dockerfile
@@ -8,7 +8,5 @@ RUN npm install
 RUN npm run build
 RUN echo "cd packages/server" >> run.sh
 RUN echo "python config-gen.py" >> run.sh
-RUN echo "ls" >> run.sh
-RUN echo "cat server-config.json" >> run.sh
 RUN echo "npm run dev" >> run.sh
 CMD ["sh", "run.sh"]

--- a/repo-client/src/functionalTest/resources/lionweb-repository-Dockerfile
+++ b/repo-client/src/functionalTest/resources/lionweb-repository-Dockerfile
@@ -1,12 +1,14 @@
-FROM node
+FROM nikolaik/python-nodejs:python3.12-nodejs22
 ARG lionwebRepositoryCommitId=xxxxxx
 RUN git clone https://github.com/LionWeb-io/lionweb-repository.git
+ADD config-gen.py lionweb-repository/packages/server
 WORKDIR lionweb-repository
 RUN git checkout ${lionwebRepositoryCommitId}
 RUN npm install
 RUN npm run build
-RUN echo "npm run database create" > run.sh
-RUN echo "npm run database init" >> run.sh
 RUN echo "cd packages/server" >> run.sh
+RUN echo "python config-gen.py" >> run.sh
+RUN echo "ls" >> run.sh
+RUN echo "cat server-config.json" >> run.sh
 RUN echo "npm run dev" >> run.sh
 CMD ["sh", "run.sh"]


### PR DESCRIPTION
This PR updates the version of the LionWeb Repository used. This requires: 
- updates in the way the configuration of the LionWeb Repository is specified in functional tests
- adding `clientId` and `repository` query params to multiple calls

This PR is based on a PR for the LionWeb Repository