### PR TITLE
Support language dependencies

### DIFF
--- a/core/src/main/kotlin/io/lionweb/lioncore/kotlin/MetamodelDefinition.kt
+++ b/core/src/main/kotlin/io/lionweb/lioncore/kotlin/MetamodelDefinition.kt
@@ -131,13 +131,17 @@ fun Language.createConcepts(vararg conceptClasses: KClass<out Node>) {
             when {
                 superClass == BaseNode::class -> Unit // Nothing to do
                 superClass.java.isInterface -> Unit
-                else -> {
-                    val extendedConcept = conceptsByClasses[superClass]
+                superClass.isSubclassOf(Node::class) -> {
+                    val extendedConcept =
+                        conceptsByClasses[superClass] ?: MetamodelRegistry.getConcept(superClass as KClass<out Node>)
                     if (extendedConcept == null) {
                         throw IllegalStateException("Cannot handle superclass $superClass for concept class $conceptClass")
                     } else {
                         concept.extendedConcept = extendedConcept
                     }
+                }
+                else -> {
+                    throw IllegalStateException("Superclass is not a node: $superClass for concept class $conceptClass")
                 }
             }
         }

--- a/core/src/main/kotlin/io/lionweb/lioncore/kotlin/MetamodelRegistry.kt
+++ b/core/src/main/kotlin/io/lionweb/lioncore/kotlin/MetamodelRegistry.kt
@@ -3,13 +3,26 @@ package io.lionweb.lioncore.kotlin
 import io.lionweb.lioncore.java.language.Annotation
 import io.lionweb.lioncore.java.language.Classifier
 import io.lionweb.lioncore.java.language.Concept
+import io.lionweb.lioncore.java.language.Containment
+import io.lionweb.lioncore.java.language.DataType
+import io.lionweb.lioncore.java.language.Enumeration
+import io.lionweb.lioncore.java.language.EnumerationLiteral
+import io.lionweb.lioncore.java.language.Feature
+import io.lionweb.lioncore.java.language.Field
+import io.lionweb.lioncore.java.language.Interface
+import io.lionweb.lioncore.java.language.Language
+import io.lionweb.lioncore.java.language.LanguageEntity
+import io.lionweb.lioncore.java.language.Link
 import io.lionweb.lioncore.java.language.LionCoreBuiltins
 import io.lionweb.lioncore.java.language.PrimitiveType
 import io.lionweb.lioncore.java.language.Property
+import io.lionweb.lioncore.java.language.Reference
+import io.lionweb.lioncore.java.language.StructuredDataType
 import io.lionweb.lioncore.java.model.AnnotationInstance
 import io.lionweb.lioncore.java.model.ClassifierInstance
 import io.lionweb.lioncore.java.model.Node
 import io.lionweb.lioncore.java.model.impl.DynamicClassifierInstance
+import io.lionweb.lioncore.java.self.LionCore
 import io.lionweb.lioncore.java.serialization.AbstractSerialization
 import io.lionweb.lioncore.java.serialization.Instantiator
 import io.lionweb.lioncore.java.serialization.PrimitiveValuesSerialization
@@ -33,6 +46,25 @@ object MetamodelRegistry {
         registerMapping(String::class, LionCoreBuiltins.getString())
         registerMapping(Int::class, LionCoreBuiltins.getInteger())
         registerMapping(Boolean::class, LionCoreBuiltins.getBoolean())
+
+        // Allow user languages to refer to M3 elements
+        registerMapping(Annotation::class, LionCore.getAnnotation())
+        registerMapping(Classifier::class, LionCore.getClassifier())
+        registerMapping(Concept::class, LionCore.getConcept())
+        registerMapping(Containment::class, LionCore.getContainment())
+        registerMapping(DataType::class, LionCore.getDataType())
+        registerMapping(Enumeration::class, LionCore.getEnumeration())
+        registerMapping(EnumerationLiteral::class, LionCore.getEnumerationLiteral())
+        registerMapping(Feature::class, LionCore.getFeature())
+        registerMapping(Field::class, LionCore.getField())
+        registerMapping(Interface::class, LionCore.getInterface())
+        registerMapping(Language::class, LionCore.getLanguage())
+        registerMapping(LanguageEntity::class, LionCore.getLanguageEntity())
+        registerMapping(Link::class, LionCore.getLink())
+        registerMapping(PrimitiveType::class, LionCore.getPrimitiveType())
+        registerMapping(Property::class, LionCore.getProperty())
+        registerMapping(Reference::class, LionCore.getReference())
+        registerMapping(StructuredDataType::class, LionCore.getStructuredDataType())
     }
 
     fun registerMapping(

--- a/core/src/test/kotlin/io/lionweb/lioncore/kotlin/LanguageDependenciesTest.kt
+++ b/core/src/test/kotlin/io/lionweb/lioncore/kotlin/LanguageDependenciesTest.kt
@@ -1,0 +1,88 @@
+package io.lionweb.lioncore.kotlin
+
+import io.lionweb.lioncore.java.language.Concept
+import io.lionweb.lioncore.java.language.Containment
+import io.lionweb.lioncore.java.language.Language
+import io.lionweb.lioncore.java.language.Reference
+import io.lionweb.lioncore.java.model.Node
+import io.lionweb.lioncore.java.self.LionCore
+import io.lionweb.lioncore.java.serialization.SerializationProvider
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+class LanguageDependenciesTest {
+    @Test fun invalidSuperclassThrows() {
+        val lang = Language("lang", "lang", "lang")
+        assertFailsWith<IllegalStateException> {
+            lang.createConcepts(LanguageDependenciesTest::class as KClass<out Node>)
+        }
+    }
+
+    @Test fun conceptExtendsOtherLanguage() {
+        val sup = Language("sup", "sup", "sup")
+        sup.createConcepts(Super::class)
+        val sub = Language("sub", "sub", "sub")
+        sub.createConcepts(Sub::class)
+        assertEquals(1, sub.elements.size)
+        val stdSer = SerializationProvider.getStandardJsonSerialization()
+        val jsonString = stdSer.serializeTreesToJsonString(sub, sup)
+        val nodes = stdSer.deserializeToNodes(jsonString)
+        assertEquals(4, nodes.size)
+    }
+
+    @Test fun conceptUsesOtherLanguage() {
+        val sup = Language("sup", "sup", "sup")
+        sup.createConcepts(Super::class)
+        val sub = Language("sub", "sub", "sub")
+        sub.createConcepts(Comp::class)
+        assertEquals(1, sub.elements.size)
+        val stdSer = SerializationProvider.getStandardJsonSerialization()
+        val jsonString = stdSer.serializeTreesToJsonString(sub, sup)
+        val nodes = stdSer.deserializeToNodes(jsonString)
+        assertEquals(6, nodes.size)
+    }
+
+    @Test fun languageCanUseM3() {
+        val extM3 = Language("ext-m3", "ext-m3", "ext-m3")
+        extM3.createConcepts(ExtendedConcept::class, CompM3::class)
+        val stdSer = SerializationProvider.getStandardJsonSerialization()
+        val jsonString = stdSer.serializeTreesToJsonString(extM3)
+        val nodes = stdSer.deserializeToNodes(jsonString)
+        assertEquals(5, nodes.size)
+        assertIs<Language>(nodes[0])
+        var concept = nodes[1]
+        assertIs<Concept>(concept)
+        assertEquals(concept.extendedConcept, LionCore.getConcept())
+        assertEquals("ExtendedConcept", concept.name)
+        concept = nodes[2]
+        assertIs<Concept>(concept)
+        assertEquals("CompM3", concept.name)
+        assertIs<Containment>(nodes[3])
+        assertIs<Reference>(nodes[4])
+    }
+}
+
+open class Super : BaseNode()
+
+class Sub : Super()
+
+class Comp : BaseNode() {
+    val comp: Super? by singleContainment("comp")
+    val ref: SpecificReferenceValue<Super>? by singleReference("ref")
+}
+
+class ExtendedConcept(
+    language: Language? = null,
+    name: String? = null,
+    id: String,
+    key: String? = null
+) : Concept(language, name, id, key)
+
+class CompM3 : BaseNode() {
+    val comp: ExtendedConcept? by singleContainment("comp")
+    val ref: SpecificReferenceValue<Concept>? by singleReference("ref")
+}
+


### PR DESCRIPTION
Allow a LionWeb language to refer to:

-  types in another **user-level** language (e.g. extend concepts, reference concepts)
-  elements in the **LionWeb M3** (e.g. extend a concept or reference some of the M3 elements)

